### PR TITLE
Exp config

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -793,7 +793,7 @@ rfc3986-validator==0.1.1
     #   -r nb-requirements.txt
     #   jsonschema
     #   jupyter-events
-rlplg @ git+https://github.com/guidj/rlplg.git@v0.17.4
+rlplg @ git+https://github.com/guidj/rlplg.git@v0.17.5
     # via
     #   -r nb-requirements.txt
     #   -r requirements.txt

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -545,7 +545,6 @@ numpy==1.23.5
     #   matplotlib
     #   opt-einsum
     #   pandas
-    #   ray
     #   rlplg
     #   scipy
     #   seaborn
@@ -762,7 +761,7 @@ pyzmq==25.0.1
     #   jupyter-server
     #   nbclassic
     #   notebook
-ray[default]==2.6.3
+ray[default]==2.9.0
     # via
     #   -r nb-requirements.txt
     #   -r requirements.txt

--- a/nb-requirements.txt
+++ b/nb-requirements.txt
@@ -520,7 +520,7 @@ rfc3986-validator==0.1.1
     # via
     #   jsonschema
     #   jupyter-events
-rlplg @ git+https://github.com/guidj/rlplg.git@v0.17.4
+rlplg @ git+https://github.com/guidj/rlplg.git@v0.17.5
     # via -r requirements.txt
 rsa==4.9
     # via

--- a/nb-requirements.txt
+++ b/nb-requirements.txt
@@ -356,7 +356,6 @@ numpy==1.23.5
     #   matplotlib
     #   opt-einsum
     #   pandas
-    #   ray
     #   rlplg
     #   scipy
     #   seaborn
@@ -498,7 +497,7 @@ pyzmq==25.0.1
     #   jupyter-server
     #   nbclassic
     #   notebook
-ray[default]==2.6.3
+ray[default]==2.9.0
     # via -r requirements.txt
 requests==2.28.2
     # via

--- a/ray-env-requirements.txt
+++ b/ray-env-requirements.txt
@@ -282,7 +282,7 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements.txt
     #   google-auth-oauthlib
-rlplg @ git+https://github.com/guidj/rlplg.git@v0.17.4
+rlplg @ git+https://github.com/guidj/rlplg.git@v0.17.5
     # via -r requirements.txt
 rsa==4.9
     # via

--- a/ray-env-requirements.txt
+++ b/ray-env-requirements.txt
@@ -186,7 +186,6 @@ numpy==1.23.5
     #   h5py
     #   jax-jumpy
     #   opt-einsum
-    #   ray
     #   rlplg
     #   scipy
     #   tensorboard
@@ -269,7 +268,7 @@ pyyaml==6.0
     # via
     #   -r requirements.txt
     #   ray
-ray[default]==2.6.3
+ray[default]==2.9.0
     # via -r requirements.txt
 requests==2.28.2
     # via

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-rlplg @ git+https://github.com/guidj/rlplg.git@v0.17.4
+rlplg @ git+https://github.com/guidj/rlplg.git@v0.17.5
 # dashboard + cluster
 ray[default]==2.6.3
 numpy==1.23.5

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 rlplg @ git+https://github.com/guidj/rlplg.git@v0.17.5
 # dashboard + cluster
-ray[default]==2.6.3
+ray[default]==2.9.0
 numpy==1.23.5
 tensorflow>=2.11.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -118,7 +118,6 @@ numpy==1.23.5
     #   h5py
     #   jax-jumpy
     #   opt-einsum
-    #   ray
     #   rlplg
     #   scipy
     #   tensorboard
@@ -168,7 +167,7 @@ pyrsistent==0.19.3
     # via jsonschema
 pyyaml==6.0
     # via ray
-ray[default]==2.6.3
+ray[default]==2.9.0
     # via -r requirements.in
 requests==2.28.2
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -178,7 +178,7 @@ requests==2.28.2
     #   tensorboard
 requests-oauthlib==1.3.1
     # via google-auth-oauthlib
-rlplg @ git+https://github.com/guidj/rlplg.git@v0.17.4
+rlplg @ git+https://github.com/guidj/rlplg.git@v0.17.5
     # via -r requirements.in
 rsa==4.9
     # via google-auth

--- a/src/daaf/constants.py
+++ b/src/daaf/constants.py
@@ -8,7 +8,7 @@ DAAF_AVERAGE_REWARD_MAPPER = "daaf-average-reward-mapper"
 DAAF_IMPUTE_REWARD_MAPPER = "daaf-impute-missing-reward-mapper"
 DAAF_LSQ_REWARD_ATTRIBUTION_MAPPER = "daaf-lsq-reward-attribution-mapper"
 MDP_WITH_OPTIONS_MAPPER = "mdp-with-options-mapper"
-DAAF_NSTEP_TD_UPDATE_MARK_MAPPER = "daaf-nstep-up-update-mark-mapper"
+DAAF_NSTEP_TD_UPDATE_MARK_MAPPER = "daaf-nstep-td-update-mark-mapper"
 AGGREGATE_MAPPER_METHODS = (
     IDENTITY_MAPPER,
     DAAF_AVERAGE_REWARD_MAPPER,

--- a/src/daaf/constants.py
+++ b/src/daaf/constants.py
@@ -4,17 +4,18 @@ Experiment constants.
 
 
 IDENTITY_MAPPER = "identity-mapper"
-AVERAGE_REWARD_MAPPER = "average-reward-mapper"
-REWARD_ESTIMATION_LSQ_MAPPER = "reward-estimation-lsq-mapper"
-REWARD_IMPUTATION_MAPPER = "reward-imputation-mapper"
+DAAF_AVERAGE_REWARD_MAPPER = "daaf-average-reward-mapper"
+DAAF_IMPUTE_REWARD_MAPPER = "daaf-impute-missing-reward-mapper"
+DAAF_LSQ_REWARD_ATTRIBUTION_MAPPER = "daaf-lsq-reward-attribution-mapper"
 MDP_WITH_OPTIONS_MAPPER = "mdp-with-options-mapper"
-NSTEP_AGGREGATE_MAPPER = "nstep-aggregate-feedback-mapper"
+DAAF_NSTEP_TD_UPDATE_MARK_MAPPER = "daaf-nstep-up-update-mark-mapper"
 AGGREGATE_MAPPER_METHODS = (
     IDENTITY_MAPPER,
-    AVERAGE_REWARD_MAPPER,
-    REWARD_IMPUTATION_MAPPER,
-    REWARD_ESTIMATION_LSQ_MAPPER,
+    DAAF_AVERAGE_REWARD_MAPPER,
+    DAAF_IMPUTE_REWARD_MAPPER,
+    DAAF_LSQ_REWARD_ATTRIBUTION_MAPPER,
     MDP_WITH_OPTIONS_MAPPER,
+    DAAF_NSTEP_TD_UPDATE_MARK_MAPPER,
 )
 OPTIONS_POLICY = "options"
 SINGLE_STEP_POLICY = "single-step"

--- a/src/daaf/policyeval/evaluation.py
+++ b/src/daaf/policyeval/evaluation.py
@@ -62,26 +62,29 @@ def run_fn(experiment_task: expconfig.ExperimentTask):
         },
     ) as exp_logger:
         state_values: Optional[np.ndarray] = None
-        for episode, (steps, state_values) in enumerate(results):
-            if episode % experiment_task.run_config.log_episode_frequency == 0:
-                logging.info(
-                    "Task %s, Episode %d: %d steps",
-                    experiment_task.run_id,
-                    episode,
-                    steps,
-                )
-                exp_logger.log(
-                    episode=episode,
-                    steps=steps,
-                    returns=np.nan,
-                    info={
-                        "state_values": state_values.tolist(),
-                    },
-                )
         try:
+            for episode, (steps, state_values) in enumerate(results):
+                if episode % experiment_task.run_config.log_episode_frequency == 0:
+                    logging.info(
+                        "Task %s, Episode %d: %d steps",
+                        experiment_task.run_id,
+                        episode,
+                        steps,
+                    )
+                    exp_logger.log(
+                        episode=episode,
+                        steps=steps,
+                        returns=np.nan,
+                        info={
+                            "state_values": state_values.tolist(),
+                        },
+                    )
+
             logging.info("\nEstimated values\n%s", state_values)
-        except NameError:
-            logging.info("Zero episodes!")
+        except Exception as err:
+            # logging.error("Task %s failed", experiment_task.run_id)
+            raise RuntimeError(f"Task {experiment_task.run_id} failed") from err
+
     env_spec.environment.close()
 
 

--- a/src/daaf/policyeval/evaluation.py
+++ b/src/daaf/policyeval/evaluation.py
@@ -119,7 +119,10 @@ def evaluate_policy(
         # To avoid misconfigured experiments (e.g. using an identity mapper
         # with the n-step DAAF aware evaluation fn) we verify the
         # mapper and functions match.
-        if daaf_config.traj_mapping_method == constants.NSTEP_AGGREGATE_MAPPER:
+        if (
+            daaf_config.traj_mapping_method
+            == constants.DAAF_NSTEP_TD_UPDATE_MARK_MAPPER
+        ):
             return nstep_td_state_values_on_aggregate_start_steps(
                 policy=policy,
                 environment=env_spec.environment,

--- a/src/daaf/replay_mapper.py
+++ b/src/daaf/replay_mapper.py
@@ -162,10 +162,14 @@ class LeastSquaresAttributionMapper(TrajMapper):
             num_states: The number of finite states in the MDP.
             num_actions: The number of finite actions in the MDP.
             reward_period: The interval at which aggregate reward is obsered.
-            state_id_fn: A function that maps observations from trajectories into a state ID (int).
-            action_id_fn: A function that maps actions from the trajectories into an action ID (int).
-            init_rtable: A table shaped [num_states, num_actions], encoding prior beliefs about the rewards for each (S, A) pair.
-            buffer_size: The maximum number of trajectories to keep in the buffer - each one should contain `reward_period` steps.
+            state_id_fn: A function that maps observations from trajectories
+                into a state ID (int).
+            action_id_fn: A function that maps actions from the trajectories
+                into an action ID (int).
+            init_rtable: A table shaped [num_states, num_actions],
+                encoding prior beliefs about the rewards for each (S, A) pair.
+            buffer_size: The maximum number of trajectories to keep
+                in the buffer - each one should contain `reward_period` steps.
 
         Note: decay isn't used when summing up the rewards for K steps.
         """
@@ -176,7 +180,8 @@ class LeastSquaresAttributionMapper(TrajMapper):
 
         if init_rtable.shape != (num_states, num_actions):
             raise ValueError(
-                f"Tensor initial_rtable must have shape [{num_states},{num_actions}]. Got [{init_rtable}]."
+                f"""Tensor initial_rtable must have shape[{num_states},{num_actions}].
+                Got [{init_rtable}]."""
             )
 
         num_factors = num_states * num_actions
@@ -245,7 +250,8 @@ class LeastSquaresAttributionMapper(TrajMapper):
                     self.num_updates += 1
 
                 except ValueError as err:
-                    # the computation failed, likely due to the matix being unsuitable (no solution).
+                    # the computation failed, likely due to the
+                    # matix being unsuitable (no solution).
                     logging.debug("Reward estimation failed: %s", err)
 
             yield dataclasses.replace(
@@ -400,7 +406,8 @@ class AbQueueBuffer:
         """
         if buffer_size < num_factors:
             raise ValueError(
-                f"Buffer size is too small for Least Squares estimate: {buffer_size}, should be >= {num_factors}"
+                f"""Buffer size is too small for Least Squares estimate.
+                 Got {buffer_size}, should be >= {num_factors}"""
             )
 
         self.buffer_size = buffer_size

--- a/src/daaf/replay_mapper.py
+++ b/src/daaf/replay_mapper.py
@@ -36,7 +36,7 @@ class TrajMapper(abc.ABC):
         raise NotImplementedError
 
 
-class IdentifyMapper(TrajMapper):
+class IdentityMapper(TrajMapper):
     """
     Makes no changes to the a trajectory.
     """
@@ -52,7 +52,7 @@ class IdentifyMapper(TrajMapper):
             yield traj_step
 
 
-class AverageRewardMapper(TrajMapper):
+class DaafAverageRewardMapper(TrajMapper):
     """
     Simulates a trajectory of periodic aggregate anonymous feedback:
       - For a set of actions, K, we take their reward, add it up, and divide it equally.
@@ -90,7 +90,7 @@ class AverageRewardMapper(TrajMapper):
                 reward_sum = 0.0
 
 
-class ImputeMissingRewardMapper(TrajMapper):
+class DaafImputeMissingRewardMapper(TrajMapper):
     """
     Simulates a trajectory of aggregate anonymous feedback:
       - For a set of actions, K, we take their reward, and sum them up.
@@ -133,7 +133,7 @@ class ImputeMissingRewardMapper(TrajMapper):
             )
 
 
-class LeastSquaresAttributionMapper(TrajMapper):
+class DaafLsqRewardAttributionMapper(TrajMapper):
     """
     Simulates a trajectory of aggregate anonymous feedback:
       - It accumulates transitions until it reaches a size M
@@ -305,9 +305,9 @@ class MdpWithOptionsMapper(TrajMapper):
             yield traj_step
 
 
-class NStepTdAggregateFeedbackMapper(TrajMapper):
+class DaafNStepTdUpdateMarkMapper(TrajMapper):
     """
-    Flags which steps an n-step TD learning
+    Marks which steps an n-step TD learning
     algorithm can update based on the availability
     of aggregate feedback.
 
@@ -359,7 +359,7 @@ class NStepTdAggregateFeedbackMapper(TrajMapper):
         yield from traj_steps
 
 
-class DropEpisodeWithTruncatedFeedbackMapper(TrajMapper):
+class DaafDropEpisodeWithTruncatedFeedbackMapper(TrajMapper):
     """
     In DAAF, the ending of an episode can coincide
     with feedback.

--- a/src/daaf/task.py
+++ b/src/daaf/task.py
@@ -55,21 +55,23 @@ def create_trajectory_mappers(
     mappers: Sequence[replay_mapper.TrajMapper] = []
     if drop_truncated_feedback_episodes:
         mappers.append(
-            replay_mapper.DropEpisodeWithTruncatedFeedbackMapper(
+            replay_mapper.DaafDropEpisodeWithTruncatedFeedbackMapper(
                 reward_period=reward_period
             )
         )
     if traj_mapping_method == constants.IDENTITY_MAPPER:
-        mappers.append(replay_mapper.IdentifyMapper())
-    elif traj_mapping_method == constants.REWARD_IMPUTATION_MAPPER:
+        mappers.append(replay_mapper.IdentityMapper())
+    elif traj_mapping_method == constants.DAAF_IMPUTE_REWARD_MAPPER:
         mappers.append(
-            replay_mapper.ImputeMissingRewardMapper(
+            replay_mapper.DaafImputeMissingRewardMapper(
                 reward_period=reward_period, impute_value=0.0
             )
         )
-    elif traj_mapping_method == constants.AVERAGE_REWARD_MAPPER:
-        mappers.append(replay_mapper.AverageRewardMapper(reward_period=reward_period))
-    elif traj_mapping_method == constants.REWARD_ESTIMATION_LSQ_MAPPER:
+    elif traj_mapping_method == constants.DAAF_AVERAGE_REWARD_MAPPER:
+        mappers.append(
+            replay_mapper.DaafAverageRewardMapper(reward_period=reward_period)
+        )
+    elif traj_mapping_method == constants.DAAF_LSQ_REWARD_ATTRIBUTION_MAPPER:
         _buffer_size, _buffer_size_mult = buffer_size_or_multiplier
         buffer_size = _buffer_size or int(
             env_spec.mdp.env_desc.num_states
@@ -77,7 +79,7 @@ def create_trajectory_mappers(
             * (_buffer_size_mult or constants.DEFAULT_BUFFER_SIZE_MULTIPLIER)
         )
         mappers.append(
-            replay_mapper.LeastSquaresAttributionMapper(
+            replay_mapper.DaafLsqRewardAttributionMapper(
                 num_states=env_spec.mdp.env_desc.num_states,
                 num_actions=env_spec.mdp.env_desc.num_actions,
                 reward_period=reward_period,
@@ -92,9 +94,9 @@ def create_trajectory_mappers(
         )
     elif traj_mapping_method == constants.MDP_WITH_OPTIONS_MAPPER:
         mappers.append(replay_mapper.MdpWithOptionsMapper())
-    elif traj_mapping_method == constants.NSTEP_AGGREGATE_MAPPER:
+    elif traj_mapping_method == constants.DAAF_NSTEP_TD_UPDATE_MARK_MAPPER:
         mappers.append(
-            replay_mapper.NStepTdAggregateFeedbackMapper(reward_period=reward_period)
+            replay_mapper.DaafNStepTdUpdateMarkMapper(reward_period=reward_period)
         )
     else:
         raise ValueError(

--- a/src/daaf/task.py
+++ b/src/daaf/task.py
@@ -45,7 +45,8 @@ def create_trajectory_mappers(
         num_actions: number of actions in the problem.
         reward_period: the frequency with which rewards are generated.
         traj_mapping_method: the method to alter trajectory data.
-        buffer_size_or_multiplier: number of elements kept in buffer or multiple for |S|x|A|xMultiplier.
+        buffer_size_or_multiplier: number of elements kept in buffer
+            or multiple for |S|x|A|xMultiplier.
 
     Returns:
         A trajectory mapper.
@@ -97,7 +98,8 @@ def create_trajectory_mappers(
         )
     else:
         raise ValueError(
-            f"Unknown cu-step-method {traj_mapping_method}. Choices: {constants.AGGREGATE_MAPPER_METHODS}"
+            f"""Unknown cu-step-method {traj_mapping_method}.
+            Choices: {constants.AGGREGATE_MAPPER_METHODS}"""
         )
     return mappers
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -199,7 +199,6 @@ numpy==1.23.5
     #   h5py
     #   jax-jumpy
     #   opt-einsum
-    #   ray
     #   rlplg
     #   scipy
     #   tensorboard
@@ -291,7 +290,7 @@ pyyaml==6.0
     # via
     #   -r requirements.txt
     #   ray
-ray[default]==2.6.3
+ray[default]==2.9.0
     # via -r requirements.txt
 requests==2.28.2
     # via

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -304,7 +304,7 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements.txt
     #   google-auth-oauthlib
-rlplg @ git+https://github.com/guidj/rlplg.git@v0.17.4
+rlplg @ git+https://github.com/guidj/rlplg.git@v0.17.5
     # via -r requirements.txt
 rsa==4.9
     # via


### PR DESCRIPTION
Refactors
  - Replay mapper names
  - Upgrades ray - so add path to files as column when reading
  - Makes data reading more efficient - first two steps were taking approximately 100s + 490s, and the main logic wasn't completing in less than 30min. Now the pipeline runs end-to-end in less than 60s on the same sample size (~9MB of logs and 2MB of metadata)